### PR TITLE
remove Julia 0.4, 0.5 warnings, enable travis for Julia 0.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ os:
   - linux
   - osx
 julia:
+  - 0.3
   - release
   - nightly
 notifications:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
-julia 0.3-
+julia 0.3
+Compat
 BinDeps
 @osx Homebrew

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,4 +1,5 @@
 using BinDeps
+using Compat
 @BinDeps.setup
 
 snappy = library_dependency("libsnappy")
@@ -16,4 +17,4 @@ provides(BuildProcess, Autotools(libtarget = Pkg.dir("Snappy") * "/deps/builds/l
     provides(Homebrew.HB, "snappy", snappy, os=:Darwin)
 end
 
-@BinDeps.install Dict(:libsnappy => :libsnappy)
+@compat @BinDeps.install Dict(:libsnappy => :libsnappy)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using Snappy
 using Base.Test
+using Compat
 
 const SnappyOK = Snappy.SnappyOK
 const SnappyInvalidInput = Snappy.SnappyInvalidInput
@@ -16,13 +17,13 @@ let
     buffer_size = 100
     for original in originals()
         # compress
-        compressed = Array(Uint8, buffer_size)
+        compressed = Array(UInt8, buffer_size)
         olen, st = Snappy.snappy_compress(original.data, compressed)
         @test st == SnappyOK
         resize!(compressed, olen)
 
         # uncompress
-        uncompressed = Array(Uint8, buffer_size)
+        uncompressed = Array(UInt8, buffer_size)
         olen, st = Snappy.snappy_uncompress(compressed, uncompressed)
         @test st == SnappyOK
         resize!(uncompressed, olen)
@@ -37,18 +38,18 @@ let
     original = "orig"
 
     # prepare too small buffer to compress
-    compressed = Array(Uint8, 1)
+    compressed = Array(UInt8, 1)
     _, st = Snappy.snappy_compress(original.data, compressed)
     @test st == SnappyBufferTooSmall
 
     # now enough buffer size
-    compressed = Array(Uint8, 100)
+    compressed = Array(UInt8, 100)
     olen, st = Snappy.snappy_compress(original.data, compressed)
     @test st == SnappyOK
     resize!(compressed, olen)
 
     # again the prepared buffer is too small to uncompress
-    uncompressed = Array(Uint8, 1)
+    uncompressed = Array(UInt8, 1)
     olen, st = Snappy.snappy_uncompress(compressed, uncompressed)
     @test st == SnappyBufferTooSmall
 end
@@ -56,7 +57,7 @@ end
 let
     # Break compressed data and detect it
     original = "orig"
-    compressed = Array(Uint8, 100)
+    compressed = Array(UInt8, 100)
     olen, st = Snappy.snappy_compress(original.data, compressed)
     @test st == SnappyOK
     resize!(compressed, olen)
@@ -69,11 +70,11 @@ end
 let
     # Estimate compressed size
     for original in originals()
-        maxlen = Snappy.snappy_max_compressed_length(uint(length(original)))
-        compressed = Array(Uint8, 100)
+        maxlen = Snappy.snappy_max_compressed_length(@compat(UInt(length(original))))
+        compressed = Array(UInt8, 100)
         olen, st = Snappy.snappy_compress(original.data, compressed)
         @test st == SnappyOK
-        #@show int(olen), int(maxlen)
+        #@show Int(olen), Int(maxlen)
         @test olen <= maxlen
     end
 end
@@ -81,7 +82,7 @@ end
 let
     # Estimate uncompressed size
     for original in originals()
-        compressed = Array(Uint8, 100)
+        compressed = Array(UInt8, 100)
         olen, st = Snappy.snappy_compress(original.data, compressed)
         @test st == SnappyOK
         resize!(compressed, olen)
@@ -98,9 +99,9 @@ let
     srand(2014)
 
     # byte arrays
-    randbytes(n) = rand(Uint8, n)
+    randbytes(n) = rand(UInt8, n)
     for original in map(randbytes, 0:100:10000)
-        @test original |> compress |> uncompress == original
+        @test uncompress(compress(original)) == original
     end
 
     # strings


### PR DESCRIPTION
- removed deprecation warnings (Note: added dependency for Compat)
- enabled travis tests for Julia v0.3
- removed support for Julia 0.3 pre-release versions
