### PR TITLE
Use dirname(@__FILE__) instead of Pkg.dir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ os:
   - osx
 julia:
   - 0.3
-  - release
+  - 0.4
+  - 0.5
   - nightly
 notifications:
   email: false

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -10,7 +10,7 @@ snappy = library_dependency("libsnappy")
 #})
 
 provides(Sources, URI("https://github.com/google/snappy/releases/download/1.1.3/snappy-1.1.3.tar.gz"), snappy, unpacked_dir="snappy-1.1.3")
-provides(BuildProcess, Autotools(libtarget = Pkg.dir("Snappy") * "/deps/builds/libsnappy/.libs/libsnappy."*BinDeps.shlib_ext), snappy, os=:Unix)
+provides(BuildProcess, Autotools(libtarget = dirname(@__FILE__) * "/builds/libsnappy/.libs/libsnappy."*BinDeps.shlib_ext), snappy, os=:Unix)
 
 @osx_only begin
     using Homebrew


### PR DESCRIPTION
This allows installing the package elsewhere.

Add testing against 0.5 to Travis - this runs the most
recent RC now, release once final tags are done.
