### PR TITLE
require Julia ≥0.5

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.3
+julia 0.5
 Compat
 BinDeps
 @osx Homebrew


### PR DESCRIPTION
Since Julia 0.3 and Julia 0.4 are no longer used in 99.9% of cases.