### PR TITLE
Increase BinaryProvider bound in REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.6
-BinaryProvider 0.2
+BinaryProvider 0.3.3


### PR DESCRIPTION
I believe things don't properly work with 0.2.