### PR TITLE
Allow installation of `snappy_jll` 1.1.9

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Snappy"
 uuid = "59d4ed8c-697a-5b28-a4c7-fe95c22820f9"
 authors = ["Kenta Sato <bicycle1885@gmail.com>"]
-version = "0.4.1"
+version = "0.4.2"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -10,8 +10,7 @@ snappy_jll = "fe1e1685-f7be-5f59-ac9f-4ca204017dfd"
 [compat]
 julia = "1.3"
 CEnum = "0.4"
-# there is something catastrophically wrong with 1.1.9
-snappy_jll = "< 1.1.9"
+snappy_jll = "1.1.8"
 
 [extras]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"


### PR DESCRIPTION
I have no idea what was the problem with snappy_jll 1.1.9, but tests pass for me on M1 (no less):
```
     Testing Running tests...
Test Summary:        | Pass  Total  Time
Low-level Interfaces |   54     54  0.1s
Test Summary:         | Pass  Total  Time
High-level Interfaces |  113    113  0.7s
     Testing Snappy tests passed
```

It'd be great to get a new version if/when this is merged.